### PR TITLE
doc: update all manga-py urls references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,12 +16,20 @@ Approximately 300 providers are available now.
 Supported resources
 -------------------
 
-see https://manga-py.github.io/manga-py/#resources-list
+see:
+
+- https://manga-py.com/manga-py/#resources-list
+- https://manga-py.github.io/manga-py/#resources-list (alternative)
+- https://yuru-yuri.github.io/manga-py/#resources-list (deprecated)
 
 Plans for improvement:
 ----------------------
 
-see https://manga-py.github.io/manga-py/improvement.html
+see:
+
+- https://manga-py.com/manga-py/improvement.html
+- https://manga-py.github.io/manga-py/improvement.html (alternative)
+
 
 How to use
 ----------
@@ -48,7 +56,10 @@ See https://github.com/manga-py/manga-py/issues/48
 
 Docker image:
 ~~~~~~~~~~~~~
-https://hub.docker.com/r/mangadl/manga-py
+See:
+
+- https://hub.docker.com/r/mangadl/manga-py
+- https://github.com/manga-py/manga-py-docker
 
 
 Downloading manga
@@ -122,7 +133,7 @@ Or docker-compose:
 
 1. Install docker compose https://docs.docker.com/compose/install/
 
-2. Download manga-py-docker https://github.com/yuru-yuri/manga-py-docker/archive/master.zip
+2. Download manga-py-docker https://github.com/manga-py/manga-py-docker/archive/master.zip
 
 3. Unzip it
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -2,7 +2,11 @@
 
 ## Поддерживаемые ресурсы
 
-Смотрите https://yuru-yuri.github.io/manga-py/#resources-list
+Смотрите:
+
+- https://manga-py.com/manga-py/#resources-list
+- https://manga-py.github.io/manga-py/#resources-list
+- https://yuru-yuri.github.io/manga-py/#resources-list
 
 
 ## Как использовать

--- a/helpers/gh_pages_content/README.md
+++ b/helpers/gh_pages_content/README.md
@@ -1,1 +1,1 @@
-Go to [README.md](https://github.com/yuru-yuri/manga-py/blob/master/README_RU.md)
+Go to [README.md](https://github.com/manga-py/manga-py/blob/master/README_RU.md)

--- a/helpers/gh_pages_content/download_btns.js
+++ b/helpers/gh_pages_content/download_btns.js
@@ -4,6 +4,7 @@
         /** global: repoUrl */
         if(typeof repoUrl == 'undefined')
         {
+            // example: https://api.github.com/repos/manga-py/manga-py/releases/latest
             // example: https://api.github.com/repos/yuru-yuri/manga-py/releases/latest
             return;
         }

--- a/manga_py/cli/__init__.py
+++ b/manga_py/cli/__init__.py
@@ -35,8 +35,11 @@ class Cli:  # pragma: no cover
             )
         except AttributeError as e:
             print(e)
-            print('Please check the domain in the table: https://yuru-yuri.github.io/manga-py/')
-            print('Make sure that the URL is correct\n\nTrace:')
+            print('Please check if your inputed domain is supported by manga-py: ')
+            print('- https://manga-py.com/manga-py/#resources-list')
+            print('- https://manga-py.github.io/manga-py/#resources-list (alternative)')
+            print('- https://yuru-yuri.github.io/manga-py/ (deprecated)')
+            print('Make sure that your inputed URL is correct\n\nTrace:')
             raise e
         self.parser.start()
         self.__progress_bar and self.__progress_bar.value > 0 and self.__progress_bar.finish()

--- a/manga_py/info.py
+++ b/manga_py/info.py
@@ -12,7 +12,12 @@ class Info:
     
     {
         'site': 'https://example.org/kumo-desu-ga-nani-ka',
-        'downloader': 'https://github.com/yuru-yuri/manga-py',
+        'downloader': [
+            'https://manga-py.com/manga-py/',
+            'https://github.com/manga-py/manga-py',
+            'https://github.com/yuru-yuri/manga-py',
+            'https://yuru-yuri.github.io/manga-py',
+        ],
         'version': '1.1.4',
         'delta': '0:00:00.003625',
         'start': '2018-06-08 17:22:24.419565',


### PR DESCRIPTION
update all existing manga-py urls in codes and docs.
some urls are off, like: https://yuru-yuri.github.io/manga-py/#resources-list .
all urls were got from src, commits, sites and, docs.
it is annoying to remember all possible urls.
and worse is to click in a broken one.

e.g.: `$ grep -rn 'yuru\|yuri\|github.com\|github.io' manga-py/` can return things like:

- https://github.com/manga-py/manga-py
- https://yuru-yuri.github.io/manga-py
- https://github.com/manga-py/manga-py-docker
- https://github.com/yuru-yuri/manga-py
- https://manga-py.github.io/manga-py
- https://travis-ci.org/yuru-yuri/manga-py
- https://api.github.com/repos/yuru-yuri/manga-py/releases/latest
- yuru-yuri.sttv.me
- https://manga-py.com

so, to resolve partially, it was listed all of them, where it is used/readed.

future work, to resolve this completelly:

- select only one domain and adopt it
    - e.g:
        - https://manga-py.com (main site).
        - https://travis-ci.org/manga-py/manga-py (travis site).
        - https://github.com/manga-py/manga-py (source code, issues).
- the others domains:
    - redirect them to the main (adopted) domain, when proper, and possible.
    - write all old and actual domains in a readme/doc.rst section, only for historical purpose.
        - e.g: manga-py.com, *.github.io, *yuru*, *yuri*, *.me, etc.
    - remove lines from this pull-request/commit to only maintain the main urls in the source-code.