### PR TITLE
cli: update `--help` sentences

### DIFF
--- a/manga_py/cli/args.py
+++ b/manga_py/cli/args.py
@@ -7,14 +7,14 @@ def _image_args(args_parser):  # pragma: no cover
     args = args_parser.add_argument_group('Image options')
 
     args.add_argument('--not-change-files-extension', action='store_const',
-                      help='Save files to archive "as is"', const=True, default=False)
+                      help='Save downloaded files to archive "as is". Default value: %(default)s.', const=True, default=False)
 
     # args.add_argument('--force-png', action='store_const',
     #                          help='Force conversation images to png format', const=True, default=False)
     # args.add_argument('--force-jpg', action='store_const',
     #                          help='Force conversation images to jpg format', const=True, default=False)
     args.add_argument('--no-webp', action='store_const', const=True, default=False,
-                      help='Force conversation webp images to jpg format')
+                      help='Convert `*.webp` images to `*.jpg` format. Default value: %(default)s.')
 
     # args.add_argument('-xt', type=int, help='Manual image crop with top side', default=0)
     # args.add_argument('-xr', type=int, help='Manual image crop with right side', default=0)
@@ -27,22 +27,21 @@ def _image_args(args_parser):  # pragma: no cover
 def _debug_args(args_parser):  # pragma: no cover
     args = args_parser.add_argument_group('Debug / Simulation options')
 
-    args.add_argument('-h', '--help', action='help', help='show help and exit')
-    args.add_argument('--print-json', action='store_const', const=True, default=False,
-                      help='Print information about the results in the form of json (after completion)')
+    args.add_argument('-h', '--help', action='help', help='Show (this) help and exit.')
+    args.add_argument('--print-json', action='store_const', const=True, default=False, help='Print information about the results in the JSON format (after completion). Default value: %(default)s.')
 
     args.add_argument('--simulate', action='store_const', const=True, default=False,
-                      help='Do not download the files and do not write anything to disk')
+            help='Simulate running Manga-py, where: 1) do not download files and, 2) do not write anything on disk. Default value: %(default)s.')
 
     args.add_argument('--show-current-chapter-info', '-cc', action='store_const', const=True, default=False,
-                      help='Show current processing chapter info')
+                      help='Show current processing chapter info. Default value: %(default)s.')
 
     # args.add_argument('--full-error', action='store_const', const=True, default=False,
     #                   help='Show full stack trace')
 
     # args.add_argument('-vv', '--log', metavar='info', type='str', help='Verbose log')
 
-    args.add_argument('--debug', action='store_true', help='Debug')
+    args.add_argument('--debug', action='store_true', help='Debug Manga-py.')
 
 
 def _downloading_args(args_parser):  # pragma: no cover
@@ -50,47 +49,46 @@ def _downloading_args(args_parser):  # pragma: no cover
 
     # args.add_argument('-U', '--update-all', action='store_const',
     #                   help='Update all. Not worked now!', const=True, default=False)
-    args.add_argument('-s', '--skip-volumes', metavar='count', type=int,
-                      help='Skip volumes', default=0)
-    args.add_argument('-c', '--max-volumes', metavar='count', type=int,
-                      help='Maximum volumes for downloading 0=All', default=0)
-    args.add_argument('--user-agent', type=str, help='Don\'t work from protected sites')
-    args.add_argument('--proxy', type=str, help='Http proxy')
+    args.add_argument('-s', '--skip-volumes', metavar='COUNT', type=int,
+                      help='Skip a total number, i.e. %(metavar)s, of volumes. Default value: %(default)s.', default=0)
+    args.add_argument('-c', '--max-volumes', metavar='COUNT', type=int,
+            help='Download a maximum number, i.e. %(metavar)s, of volumes. E.g.: `--max-volumes 2` will download at most 2 volumes. If %(metavar)s is `0` (zero) then it will download all avaliable volumes. Default value: %(default)s.', default=0)
+    args.add_argument('--user-agent', type=str, help='Set an user-agent. Don\'t work from protected sites. Default value: %(default)s.')
+    args.add_argument('--proxy', type=str, help='Set a http proxy. Default value: %(default)s.')
     args.add_argument('--reverse-downloading', action='store_const',
-                      help='Reverse volumes downloading', const=True, default=False)
-    args.add_argument('--rewrite-exists-archives', action='store_const', const=True,
-                      default=False)
-    args.add_argument('-nm', '--max-threads', type=int, help='Max threads images downloading', default=None)
+                      help='Download manga volumes in a reverse order. By default, the manga will be downloaded in a ascendent order (i.e. volume 00, volume 01, volume 02...). If `--reverse-downloading` has been actived, then the manga will be downloaded in a descendent order (i.e. volume 99, volume 98, volume 97...). Default value: %(default)s.', const=True, default=False)
+    args.add_argument('--rewrite-exists-archives', action='store_const', help='(Re)Download manga volume if it already exists locally in the directory destination. Your manga files can be overwrited, so be careful. Default value: %(default)s.', const=True, default=False)
+    args.add_argument('-nm', '--max-threads', type=int, help='Set the maximum number of threads, i.e. MAX_THREADS, to be ready to use when downloading the manga images. Default value: %(default)s.', default=None)
     args.add_argument('--zero-fill', action='store_const', const=True, default=False,
-                      help='Adds 0 to the end for all chapters (vol_001.zip -> vol_001-0.zip)')
+                      help='Pad a `-0` (dash-and-zero) at right for all downloaded manga volume filenames. E.g. from `vol_001.zip` to `vol_001-0.zip`. It is useful to standardize the filenames between normal manga volumes (e.g. vol_006.zip) and the extra/bonuses/updated/corrected manga volumes (e.g. vol_006-5.zip) released by scanlators groups. Default value: %(default)s.')
     args.add_argument('-N', '--with-manga-name', action='store_const', const=True, default=False,
-                      help='Adds 0 to the end for all chapters (vol_001.zip -> manga_name-vol_001.zip)')
-    args.add_argument('--min-free-space', metavar='Mb', type=int,
-                      help='Minimum free disc space', default=100)
+                      help='Pad the manga name at left for all downloaded manga volumes filenames. E.g. from `vol_001.zip` to `manga_name-vol_001.zip`. Default value: %(default)s.')
+    args.add_argument('--min-free-space', metavar='MB', type=int,
+                      help='Alert when the minimum free disc space, i.e. MB, is reached. Insert it in order of megabytes (Mb). Default value: %(default)s.', default=100)
 
 
 def _reader_args(args_parser):  # pragma: no cover
     args = args_parser.add_argument_group('Archive options')
 
     args.add_argument('--cbz', action='store_const', default=False,
-                      const=True, help='Make *.cbz archives (for reader)')
+                      const=True, help='Make `*.cbz` archives (for reader). Default value: %(default)s.')
 
     args.add_argument('--rename-pages', action='store_const', default=False, const=True,
-                      help='Normalize images names. (example: 0_page_1.jpg -> 0001.jpg)')
+                      help='Normalize image filenames. E.g. from `0_page_1.jpg` to `0001.jpg`. Default value: %(default)s.')
 
 
 def get_cli_arguments() -> ArgumentParser:  # pragma: no cover
     args_parser = ArgumentParser(add_help=False)
     args = args_parser.add_argument_group('General options')
 
-    args.add_argument('url', metavar='url', type=str, help='Downloaded url')
-    args.add_argument('--version', action='version', version=__version__)
+    args.add_argument('url', metavar='URL', type=str, help='%(metavar)s, i.e. link from manga, to be downloaded.')
+    args.add_argument('--version', action='version', version=__version__, help='Show Manga-py\'s version number and exit.')
 
-    args.add_argument('-n', '--name', metavar='name', type=str, help='Manga name', default='')
-    args.add_argument('-d', '--destination', metavar='path', type=str,
-                      help='Destination folder (Default = current directory', default='Manga')
+    args.add_argument('-n', '--name', metavar='NAME', type=str, help='Rename manga, i.e. by %(metavar)s, and its folder to where it will be saved locally. Default value: %(default)s.', default='')
+    args.add_argument('-d', '--destination', metavar='PATH', type=str,
+            help='Destination folder to where the manga will be saved locally, i.e. `./%(metavar)s/manga_name/`. E.g.: `./%(default)s/manga_name/` or `./FOO/manga_name/`. Default value: %(default)s.', default='Manga')
     args.add_argument('-np', '--no-progress', metavar='no-progress', action='store_const',
-                      const=True, help='Don\'t show progress bar', default=False)
+                      const=True, help='Don\'t show progress bar. Default value: %(default)s', default=False)
     # future
     # args_parser.add_argument('--server', action='store_const', const=True, help='Run web interface',
     #                          default=False)


### PR DESCRIPTION
What
====
Re(type) sentences to be showed when running `--help` option.

Why
===
The `--help` option is the main source of information about how to run Manga-py.
It deserves constant attention and improvement to be more easily readable.

Where
=====
On `./manga_py/cli/args.py` file, edit `args.add_argument()` function calls.
Specifically the `metavar`, `help` and, `default` method parameters.

How
===
- Improve the `--help` option with more useful information.
- Use `from argparse import ArgumentParser` module, the choice of Manga-py developers.
- Edit `add_argument()` method, on its `metavar`, `help` and, `default` parameters.
- Reference: [`add_argument()`](https://docs.python.org/3/library/argparse.html#the-add-argument-method).
- Include text in options that hadn't a `help` parameter yet.
- Update `help` texts with:
    - what the option does;
    - why it does it;
    - unambiguous information;
    - typos and grammar spells;
    - detailed data (e.g. `default values`);
    - examples and use cases;
    - standardize all text:
        - capitalize phrases and sentences;
        - put period after sentences;
        - uppercase option parameter references (e.g: `--name name` to `--name NAME`);

Results
=======
Below is listed the result when running `python3 manga.py --help`.

- before this commit:
```
$ python3 ./manga.py --help
usage: manga.py [--version] [-n name] [-d path] [-np]
                [--not-change-files-extension] [--no-webp] [--cbz]
                [--rename-pages] [-s count] [-c count]
                [--user-agent USER_AGENT] [--proxy PROXY]
                [--reverse-downloading] [--rewrite-exists-archives]
                [-nm MAX_THREADS] [--zero-fill] [-N] [--min-free-space Mb]
                [-h] [--print-json] [--simulate] [--show-current-chapter-info]
                [--debug]
                url

General options:
  url                   Downloaded url
  --version             show program's version number and exit
  -n name, --name name  Manga name
  -d path, --destination path
                        Destination folder (Default = current directory
  -np, --no-progress    Don't show progress bar

Image options:
  --not-change-files-extension
                        Save files to archive "as is"
  --no-webp             Force conversation webp images to jpg format

Archive options:
  --cbz                 Make *.cbz archives (for reader)
  --rename-pages        Normalize images names. (example: 0_page_1.jpg ->
                        0001.jpg)

Downloading options:
  -s count, --skip-volumes count
                        Skip volumes
  -c count, --max-volumes count
                        Maximum volumes for downloading 0=All
  --user-agent USER_AGENT
                        Don't work from protected sites
  --proxy PROXY         Http proxy
  --reverse-downloading
                        Reverse volumes downloading
  --rewrite-exists-archives
  -nm MAX_THREADS, --max-threads MAX_THREADS
                        Max threads images downloading
  --zero-fill           Adds 0 to the end for all chapters (vol_001.zip ->
                        vol_001-0.zip)
  -N, --with-manga-name
                        Adds 0 to the end for all chapters (vol_001.zip ->
                        manga_name-vol_001.zip)
  --min-free-space Mb   Minimum free disc space

Debug / Simulation options:
  -h, --help            show help and exit
  --print-json          Print information about the results in the form of
                        json (after completion)
  --simulate            Do not download the files and do not write anything to
                        disk
  --show-current-chapter-info, -cc
                        Show current processing chapter info
  --debug               Debug

```

- after this commit:
```
$ python3 ./manga.py --help
usage: manga.py [--version] [-n NAME] [-d PATH] [-np]
                [--not-change-files-extension] [--no-webp] [--cbz]
                [--rename-pages] [-s COUNT] [-c COUNT]
                [--user-agent USER_AGENT] [--proxy PROXY]
                [--reverse-downloading] [--rewrite-exists-archives]
                [-nm MAX_THREADS] [--zero-fill] [-N] [--min-free-space MB]
                [-h] [--print-json] [--simulate] [--show-current-chapter-info]
                [--debug]
                URL

General options:
  URL                   URL, i.e. link from manga, to be downloaded.
  --version             Show Manga-py's version number and exit.
  -n NAME, --name NAME  Rename manga, i.e. by NAME, and its folder to where it
                        will be saved locally. Default value: .
  -d PATH, --destination PATH
                        Destination folder to where the manga will be saved
                        locally, i.e. `./PATH/manga_name/`. E.g.:
                        `./Manga/manga_name/` or `./FOO/manga_name/`. Default
                        value: Manga.
  -np, --no-progress    Don't show progress bar. Default value: False

Image options:
  --not-change-files-extension
                        Save downloaded files to archive "as is". Default
                        value: False.
  --no-webp             Convert `*.webp` images to `*.jpg` format. Default
                        value: False.

Archive options:
  --cbz                 Make `*.cbz` archives (for reader). Default value:
                        False.
  --rename-pages        Normalize image filenames. E.g. from `0_page_1.jpg` to
                        `0001.jpg`. Default value: False.

Downloading options:
  -s COUNT, --skip-volumes COUNT
                        Skip a total number, i.e. COUNT, of volumes. Default
                        value: 0.
  -c COUNT, --max-volumes COUNT
                        Download a maximum number, i.e. COUNT, of volumes.
                        E.g.: `--max-volumes 2` will download at most 2
                        volumes. If COUNT is `0` (zero) then it will download
                        all avaliable volumes. Default value: 0.
  --user-agent USER_AGENT
                        Set an user-agent. Don't work from protected sites.
                        Default value: None.
  --proxy PROXY         Set a http proxy. Default value: None.
  --reverse-downloading
                        Download manga volumes in a reverse order. By default,
                        the manga will be downloaded in a ascendent order
                        (i.e. volume 00, volume 01, volume 02...). If
                        `--reverse-downloading` has been actived, then the
                        manga will be downloaded in a descendent order (i.e.
                        volume 99, volume 98, volume 97...). Default value:
                        False.
  --rewrite-exists-archives
                        (Re)Download manga volume if it already exists locally
                        in the directory destination. Your manga files can be
                        overwrited, so be careful. Default value: False.
  -nm MAX_THREADS, --max-threads MAX_THREADS
                        Set the maximum number of threads, i.e. MAX_THREADS,
                        to be ready to use when downloading the manga images.
                        Default value: None.
  --zero-fill           Pad a `-0` (dash-and-zero) at right for all downloaded
                        manga volume filenames. E.g. from `vol_001.zip` to
                        `vol_001-0.zip`. It is useful to standardize the
                        filenames between normal manga volumes (e.g.
                        vol_006.zip) and the extra/bonuses/updated/corrected
                        manga volumes (e.g. vol_006-5.zip) released by
                        scanlators groups. Default value: False.
  -N, --with-manga-name
                        Pad the manga name at left for all downloaded manga
                        volumes filenames. E.g. from `vol_001.zip` to
                        `manga_name-vol_001.zip`. Default value: False.
  --min-free-space MB   Alert when the minimum free disc space, i.e. MB, is
                        reached. Insert it in order of megabytes (Mb). Default
                        value: 100.

Debug / Simulation options:
  -h, --help            Show (this) help and exit.
  --print-json          Print information about the results in the JSON format
                        (after completion). Default value: False.
  --simulate            Simulate running Manga-py, where: 1) do not download
                        files and, 2) do not write anything on disk. Default
                        value: False.
  --show-current-chapter-info, -cc
                        Show current processing chapter info. Default value:
                        False.
  --debug               Debug Manga-py.

```

Future work
===========
- Remove typos.
- Shorten sentences and phrases.
- Exemplify each option use.
- Include all `default` value programmatically by `argparse` module.