### PR TITLE
doc: include project name on first line of readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Manga-Downloader |Travis CI result|
+Manga-py |Travis CI result|
 ===================================
 
 Universal assistant download manga.


### PR DESCRIPTION
What
====
Change the term `Manga-Downloader` to `Manga-py` on README.

Why
===
- Identify the project firstly and faster.
- Googleable because will be formatted in a HTML head H1 (SEO).
- Unconfuse the reader between `Manga-py` and `Manga-downloader`.
- Is `manga-downloader`:
    - the project name? or...
    - the slogan? or...
    - the keywords? or... anything.

Where
=====
Onto `./README.rst`

How
===
- Rewrite the `./README.md` first line.
- From `Manga-Downloader` to `Manga-py`.

Results
=======
Before this commit:

```
Manga-Downloader |Travis CI result|
===================================
```

After this commit:

```
Manga-py |Travis CI result|
===================================
```

Future works
============
- Search for `Manga-Downloader` on other files.