### PR TITLE
fix: print defaults values programmatically on `--help`

### DIFF
--- a/manga_py/cli/args.py
+++ b/manga_py/cli/args.py
@@ -1,4 +1,4 @@
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 
 from manga_py.meta import __version__
 
@@ -7,14 +7,14 @@ def _image_args(args_parser):  # pragma: no cover
     args = args_parser.add_argument_group('Image options')
 
     args.add_argument('--not-change-files-extension', action='store_true',
-                      help='Save downloaded files to archive "as is". Default value: %(default)s.')
+                      help='Save downloaded files to archive "as is".')
 
     # args.add_argument('--force-png', action='store_const',
     #                          help='Force conversation images to png format', const=True, default=False)
     # args.add_argument('--force-jpg', action='store_const',
     #                          help='Force conversation images to jpg format', const=True, default=False)
     args.add_argument('--no-webp', action='store_true',
-                      help='Convert `*.webp` images to `*.jpg` format. Default value: %(default)s.')
+                      help='Convert `*.webp` images to `*.jpg` format.')
 
     # args.add_argument('-xt', type=int, help='Manual image crop with top side', default=0)
     # args.add_argument('-xr', type=int, help='Manual image crop with right side', default=0)
@@ -29,13 +29,13 @@ def _debug_args(args_parser):  # pragma: no cover
 
     args.add_argument('-h', '--help', action='help', help='Show this help and exit.')
     args.add_argument('--print-json', action='store_true',
-                      help='Print information about the results in the JSON format (after completion). Default value: %(default)s.')
+                      help='Print information about the results in the JSON format (after completion).')
 
     args.add_argument('--simulate', action='store_true',
-                      help='Simulate running Manga-py, where: 1) do not download files and, 2) do not write anything on disk. Default value: %(default)s.')
+                      help='Simulate running Manga-py, where: 1) do not download files and, 2) do not write anything on disk.')
 
     args.add_argument('--show-current-chapter-info', '-cc', action='store_true',
-                      help='Show current processing chapter info. Default value: %(default)s.')
+                      help='Show current processing chapter info.')
 
     # args.add_argument('--full-error', action='store_true',
     #                   help='Show full stack trace')
@@ -52,49 +52,49 @@ def _downloading_args(args_parser):  # pragma: no cover
     # args.add_argument('-U', '--update-all', action='store_const',
     #                   help='Update all. Not worked now!', const=True, default=False)
     args.add_argument('-s', '--skip-volumes', metavar='COUNT', type=int,
-                      help='Skip a total number, i.e. %(metavar)s, of volumes. Default value: %(default)s.', default=0)
+                      help='Skip a total number, i.e. %(metavar)s, of volumes.', default=0)
     args.add_argument('-c', '--max-volumes', metavar='COUNT', type=int, default=0,
-                      help='Download a maximum number, i.e. %(metavar)s, of volumes. E.g.: `--max-volumes 2` will download at most 2 volumes. If %(metavar)s is `0` (zero) then it will download all available volumes. Default value: %(default)s.')
+                      help='Download a maximum number, i.e. %(metavar)s, of volumes. E.g.: `--max-volumes 2` will download at most 2 volumes. If %(metavar)s is `0` (zero) then it will download all available volumes.')
     args.add_argument('--user-agent', type=str,
-                      help='Set an user-agent. Don\'t work from protected sites. Default value: %(default)s.')
-    args.add_argument('--proxy', type=str, help='Set a http proxy. Default value: %(default)s.')
+                      help='Set an user-agent. Don\'t work from protected sites.')
+    args.add_argument('--proxy', type=str, help='Set a http proxy.')
     args.add_argument('--reverse-downloading', action='store_true',
-                      help='Download manga volumes in a reverse order. By default, the manga will be downloaded in a ascendent order (i.e. volume 00, volume 01, volume 02...). If `--reverse-downloading` has been actived, then the manga will be downloaded in a descendent order (i.e. volume 99, volume 98, volume 97...). Default value: %(default)s.')
+                      help='Download manga volumes in a reverse order. By default, the manga will be downloaded in a ascendent order (i.e. volume 00, volume 01, volume 02...). If `--reverse-downloading` has been actived, then the manga will be downloaded in a descendent order (i.e. volume 99, volume 98, volume 97...).')
     args.add_argument('--rewrite-exists-archives', action='store_true',
-                      help='(Re)Download manga volume if it already exists locally in the directory destination. Your manga files can be overwrited, so be careful. Default value: %(default)s.')
+                      help='(Re)Download manga volume if it already exists locally in the directory destination. Your manga files can be overwrited, so be careful.')
     args.add_argument('-nm', '--max-threads', type=int, default=None,
-                      help='Set the maximum number of threads, i.e. MAX_THREADS, to be ready to use when downloading the manga images. Default value: %(default)s.')
+                      help='Set the maximum number of threads, i.e. MAX_THREADS, to be ready to use when downloading the manga images.')
     args.add_argument('--zero-fill', action='store_true',
-                      help='Pad a `-0` (dash-and-zero) at right for all downloaded manga volume filenames. E.g. from `vol_001.zip` to `vol_001-0.zip`. It is useful to standardize the filenames between normal manga volumes (e.g. vol_006.zip) and the extra/bonuses/updated/corrected manga volumes (e.g. vol_006-5.zip) released by scanlators groups. Default value: %(default)s.')
+                      help='Pad a `-0` (dash-and-zero) at right for all downloaded manga volume filenames. E.g. from `vol_001.zip` to `vol_001-0.zip`. It is useful to standardize the filenames between normal manga volumes (e.g. vol_006.zip) and the extra/bonuses/updated/corrected manga volumes (e.g. vol_006-5.zip) released by scanlators groups.')
     args.add_argument('-N', '--with-manga-name', action='store_true',
-                      help='Pad the manga name at left for all downloaded manga volumes filenames. E.g. from `vol_001.zip` to `manga_name-vol_001.zip`. Default value: %(default)s.')
+                      help='Pad the manga name at left for all downloaded manga volumes filenames. E.g. from `vol_001.zip` to `manga_name-vol_001.zip`.')
     args.add_argument('--min-free-space', metavar='MB', type=int, default=100,
-                      help='Alert when the minimum free disc space, i.e. MB, is reached. Insert it in order of megabytes (Mb). Default value: %(default)s.')
+                      help='Alert when the minimum free disc space, i.e. MB, is reached. Insert it in order of megabytes (Mb).')
 
 
 def _reader_args(args_parser):  # pragma: no cover
     args = args_parser.add_argument_group('Archive options')
 
     args.add_argument('--cbz', action='store_true',
-                      help='Make `*.cbz` archives (for reader). Default value: %(default)s.')
+                      help='Make `*.cbz` archives (for reader).')
 
     args.add_argument('--rename-pages', action='store_true',
-                      help='Normalize image filenames. E.g. from `0_page_1.jpg` to `0001.jpg`. Default value: %(default)s.')
+                      help='Normalize image filenames. E.g. from `0_page_1.jpg` to `0001.jpg`.')
 
 
 def get_cli_arguments() -> ArgumentParser:  # pragma: no cover
-    args_parser = ArgumentParser(add_help=False)
+    args_parser = ArgumentParser(add_help=False, formatter_class=ArgumentDefaultsHelpFormatter)
     args = args_parser.add_argument_group('General options')
 
     args.add_argument('url', metavar='URL', type=str, help='%(metavar)s, i.e. link from manga, to be downloaded.')
     args.add_argument('--version', action='version', version=__version__, help='Show Manga-py\'s version number and exit.')
 
     args.add_argument('-n', '--name', metavar='NAME', type=str, default='',
-                      help='Rename manga, i.e. by %(metavar)s, and its folder to where it will be saved locally. Default value: %(default)s.')
+                      help='Rename manga, i.e. by %(metavar)s, and its folder to where it will be saved locally.')
     args.add_argument('-d', '--destination', metavar='PATH', type=str, default='Manga',
-                      help='Destination folder to where the manga will be saved locally, i.e. `./%(metavar)s/manga_name/`. E.g.: `./%(default)s/manga_name/` or `./FOO/manga_name/`. Default value: %(default)s.')
+                      help='Destination folder to where the manga will be saved locally, i.e. `./%(metavar)s/manga_name/`.')
     args.add_argument('-np', '--no-progress', action='store_true',
-                      help='Don\'t show progress bar. Default value: %(default)s')
+                      help='Don\'t show progress bar.')
     # future
     # args_parser.add_argument('--server', action='store_const', const=True, help='Run web interface',
     #                          default=False)


### PR DESCRIPTION
What
====

Show default value for each `--help` options programmatically.

Why
===

- Use a one-liner argparse parameter [`ArgumentDefaultsHelpFormatter`](https://docs.python.org/3/library/argparse.html#argparse.ArgumentDefaultsHelpFormatter).
- Remove lots of sub-strings.
- Better then insert the default values manually, or by variables, onto each option-help string description.
- Easy to maintain (less code).

Where
=====

On `./manga_py/cli/args.py`.

How
===

Steps to include defaults values:

1. Import `ArgumentDefaultsHelpFormatter`:
    ```python
    from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
    ```
2. Remove all default-value variable references, like this one:
    ```python
    args.add_argument('--cbz', action='store_true',
                      OLD LINE # help='Make `*.cbz` archives (for reader). Default value: %(default)s.')
                      help='Make `*.cbz` archives (for reader).')
    ```
3. Pass to argparser's constructor a formatter that shows default values from each help-options (i.e. `ArgumentDefaultsHelpFormatter`):
    ```python
    OLD LINE # args_parser = ArgumentParser(add_help=False)
    args_parser = ArgumentParser(add_help=False, formatter_class=ArgumentDefaultsHelpFormatter)
    ```

Results
=======

Bellow are listed a before and after states when this commit is applied:

- Before this commit:
```
(my_env) $ python3 ./manga.py --help
usage: manga.py [--version] [-n NAME] [-d PATH] [-np]
                [--not-change-files-extension] [--no-webp] [--cbz]
                [--rename-pages] [-s COUNT] [-c COUNT]
                [--user-agent USER_AGENT] [--proxy PROXY]
                [--reverse-downloading] [--rewrite-exists-archives]
                [-nm MAX_THREADS] [--zero-fill] [-N] [--min-free-space MB]
                [-h] [--print-json] [--simulate] [--show-current-chapter-info]
                [--debug] [-q]
                URL

General options:
  URL                   URL, i.e. link from manga, to be downloaded.
  --version             Show Manga-py's version number and exit.
  -n NAME, --name NAME  Rename manga, i.e. by NAME, and its folder to where it
                        will be saved locally. Default value: .
  -d PATH, --destination PATH
                        Destination folder to where the manga will be saved
                        locally, i.e. `./PATH/manga_name/`. E.g.:
                        `./Manga/manga_name/` or `./FOO/manga_name/`. Default
                        value: Manga.
  -np, --no-progress    Don't show progress bar. Default value: False

Image options:
  --not-change-files-extension
                        Save downloaded files to archive "as is". Default
                        value: False.
  --no-webp             Convert `*.webp` images to `*.jpg` format. Default
                        value: False.

Archive options:
  --cbz                 Make `*.cbz` archives (for reader). Default value:
                        False.
  --rename-pages        Normalize image filenames. E.g. from `0_page_1.jpg` to
                        `0001.jpg`. Default value: False.

Downloading options:
  -s COUNT, --skip-volumes COUNT
                        Skip a total number, i.e. COUNT, of volumes. Default
                        value: 0.
  -c COUNT, --max-volumes COUNT
                        Download a maximum number, i.e. COUNT, of volumes.
                        E.g.: `--max-volumes 2` will download at most 2
                        volumes. If COUNT is `0` (zero) then it will download
                        all available volumes. Default value: 0.
  --user-agent USER_AGENT
                        Set an user-agent. Don't work from protected sites.
                        Default value: None.
  --proxy PROXY         Set a http proxy. Default value: None.
  --reverse-downloading
                        Download manga volumes in a reverse order. By default,
                        the manga will be downloaded in a ascendent order
                        (i.e. volume 00, volume 01, volume 02...). If
                        `--reverse-downloading` has been actived, then the
                        manga will be downloaded in a descendent order (i.e.
                        volume 99, volume 98, volume 97...). Default value:
                        False.
  --rewrite-exists-archives
                        (Re)Download manga volume if it already exists locally
                        in the directory destination. Your manga files can be
                        overwrited, so be careful. Default value: False.
  -nm MAX_THREADS, --max-threads MAX_THREADS
                        Set the maximum number of threads, i.e. MAX_THREADS,
                        to be ready to use when downloading the manga images.
                        Default value: None.
  --zero-fill           Pad a `-0` (dash-and-zero) at right for all downloaded
                        manga volume filenames. E.g. from `vol_001.zip` to
                        `vol_001-0.zip`. It is useful to standardize the
                        filenames between normal manga volumes (e.g.
                        vol_006.zip) and the extra/bonuses/updated/corrected
                        manga volumes (e.g. vol_006-5.zip) released by
                        scanlators groups. Default value: False.
  -N, --with-manga-name
                        Pad the manga name at left for all downloaded manga
                        volumes filenames. E.g. from `vol_001.zip` to
                        `manga_name-vol_001.zip`. Default value: False.
  --min-free-space MB   Alert when the minimum free disc space, i.e. MB, is
                        reached. Insert it in order of megabytes (Mb). Default
                        value: 100.

Debug / Simulation options:
  -h, --help            Show this help and exit.
  --print-json          Print information about the results in the JSON format
                        (after completion). Default value: False.
  --simulate            Simulate running Manga-py, where: 1) do not download
                        files and, 2) do not write anything on disk. Default
                        value: False.
  --show-current-chapter-info, -cc
                        Show current processing chapter info. Default value:
                        False.
  --debug               Debug Manga-py.
  -q, --quiet           Dont show any messages.
```

- After this commit:
```
(my_env) $ python3 ./manga-py --help
usage: manga.py [--version] [-n NAME] [-d PATH] [-np]
                [--not-change-files-extension] [--no-webp] [--cbz]
                [--rename-pages] [-s COUNT] [-c COUNT]
                [--user-agent USER_AGENT] [--proxy PROXY]
                [--reverse-downloading] [--rewrite-exists-archives]
                [-nm MAX_THREADS] [--zero-fill] [-N] [--min-free-space MB]
                [-h] [--print-json] [--simulate] [--show-current-chapter-info]
                [--debug] [-q]
                URL

General options:
  URL                   URL, i.e. link from manga, to be downloaded.
  --version             Show Manga-py's version number and exit.
  -n NAME, --name NAME  Rename manga, i.e. by NAME, and its folder to where it
                        will be saved locally. (default: )
  -d PATH, --destination PATH
                        Destination folder to where the manga will be saved
                        locally, i.e. `./PATH/manga_name/`. (default: Manga)
  -np, --no-progress    Don't show progress bar. (default: False)

Image options:
  --not-change-files-extension
                        Save downloaded files to archive "as is". (default:
                        False)
  --no-webp             Convert `*.webp` images to `*.jpg` format. (default:
                        False)

Archive options:
  --cbz                 Make `*.cbz` archives (for reader). (default: False)
  --rename-pages        Normalize image filenames. E.g. from `0_page_1.jpg` to
                        `0001.jpg`. (default: False)

Downloading options:
  -s COUNT, --skip-volumes COUNT
                        Skip a total number, i.e. COUNT, of volumes. (default:
                        0)
  -c COUNT, --max-volumes COUNT
                        Download a maximum number, i.e. COUNT, of volumes.
                        E.g.: `--max-volumes 2` will download at most 2
                        volumes. If COUNT is `0` (zero) then it will download
                        all available volumes. (default: 0)
  --user-agent USER_AGENT
                        Set an user-agent. Don't work from protected sites.
                        (default: None)
  --proxy PROXY         Set a http proxy. (default: None)
  --reverse-downloading
                        Download manga volumes in a reverse order. By default,
                        the manga will be downloaded in a ascendent order
                        (i.e. volume 00, volume 01, volume 02...). If
                        `--reverse-downloading` has been actived, then the
                        manga will be downloaded in a descendent order (i.e.
                        volume 99, volume 98, volume 97...). (default: False)
  --rewrite-exists-archives
                        (Re)Download manga volume if it already exists locally
                        in the directory destination. Your manga files can be
                        overwrited, so be careful. (default: False)
  -nm MAX_THREADS, --max-threads MAX_THREADS
                        Set the maximum number of threads, i.e. MAX_THREADS,
                        to be ready to use when downloading the manga images.
                        (default: None)
  --zero-fill           Pad a `-0` (dash-and-zero) at right for all downloaded
                        manga volume filenames. E.g. from `vol_001.zip` to
                        `vol_001-0.zip`. It is useful to standardize the
                        filenames between normal manga volumes (e.g.
                        vol_006.zip) and the extra/bonuses/updated/corrected
                        manga volumes (e.g. vol_006-5.zip) released by
                        scanlators groups. (default: False)
  -N, --with-manga-name
                        Pad the manga name at left for all downloaded manga
                        volumes filenames. E.g. from `vol_001.zip` to
                        `manga_name-vol_001.zip`. (default: False)
  --min-free-space MB   Alert when the minimum free disc space, i.e. MB, is
                        reached. Insert it in order of megabytes (Mb).
                        (default: 100)

Debug / Simulation options:
  -h, --help            Show this help and exit.
  --print-json          Print information about the results in the JSON format
                        (after completion). (default: False)
  --simulate            Simulate running Manga-py, where: 1) do not download
                        files and, 2) do not write anything on disk. (default:
                        False)
  --show-current-chapter-info, -cc
                        Show current processing chapter info. (default: False)
  --debug               Debug Manga-py. (default: False)
  -q, --quiet           Dont show any messages. (default: False)
```

Future work
===========

- Use more [argparse features](https://docs.python.org/3/library/argparse.html#argumentparser-objects).
- Break/format big-strings on `args.py`.
- References:
    - [Stackoverflow answers](https://stackoverflow.com/a/12151325/1467021).
    - [Argparser formatter python buildin](https://docs.python.org/3/library/argparse.html#argparse.ArgumentDefaultsHelpFormatter).

---