### PR TITLE
Inprove viz

### DIFF
--- a/manga_py/crypt/viz_com.py
+++ b/manga_py/crypt/viz_com.py
@@ -4,31 +4,25 @@ from PIL import Image
 from sys import stderr
 
 
+WIDTH = 256
+HEIGHT = 257
+KEY = 42016
+
 class VizComMatrix:
     @classmethod
-    def get_image_meta(cls, path: str) -> Optional[List[int]]:
-        pattern = None
-        try:
-            with open(path, 'rb') as r:
-                # read one line. get pattern
-                pattern = re.search(r'([\da-f]{2}(?::[\da-f]{2})+)', str(r.readline(1024))).group(1)
-                pattern = [int('0x%s' % i, 16) for i in pattern.split(':')]
-        except Exception as e:
-            print('Error extract pattern. Path: %s' % path, file=stderr)
-        return pattern
-
-    @classmethod
     def solve_image(cls, path: str, metadata: dict) -> Optional[Image.Image]:
-        meta = cls.get_image_meta(path)
-        if meta is None:
-            return
-
         orig = Image.open(path)  # type: Image.Image
         new_size = (orig.size[0] - 90, orig.size[1] - 140)
         ref = Image.new(orig.mode, new_size)  # type: Image.Image
         ref.paste(orig)
 
-        width, height = metadata["width"], metadata["height"]
+        exif = orig._getexif()
+        if KEY in exif:
+            key = [int(i, 16) for i in exif[KEY].split(':')]
+            width, height = exif[WIDTH], exif[HEIGHT]
+        else:
+            key = []
+            width, height = metadata['width'], metadata['height']
         small_width = int(width / 10)
         small_height = int(height / 15)
 
@@ -56,7 +50,7 @@ class VizComMatrix:
             small_width + (width - 10 * small_width), height - 2 * small_height,
         ))
 
-        for i, j in enumerate(cls.get_image_meta(path)):
+        for i, j in enumerate(key):
             cls.paste(ref, orig, (
                 (i % 8 + 1) * (small_width + 10), (int(i / 8) + 1) * (small_height + 10),
                 small_width, small_height,

--- a/manga_py/crypt/viz_com.py
+++ b/manga_py/crypt/viz_com.py
@@ -18,7 +18,7 @@ class VizComMatrix:
         return pattern
 
     @classmethod
-    def solve_image(cls, path: str) -> Optional[Image.Image]:
+    def solve_image(cls, path: str, metadata: dict) -> Optional[Image.Image]:
         meta = cls.get_image_meta(path)
         if meta is None:
             return
@@ -28,7 +28,7 @@ class VizComMatrix:
         ref = Image.new(orig.mode, new_size)  # type: Image.Image
         ref.paste(orig)
 
-        width, height = ref.size
+        width, height = metadata["width"], metadata["height"]
         small_width = int(width / 10)
         small_height = int(height / 15)
 

--- a/manga_py/providers/viz_com.py
+++ b/manga_py/providers/viz_com.py
@@ -1,5 +1,6 @@
 from sys import stderr
 from pathlib import Path
+from json import loads
 
 from manga_py import meta
 from manga_py.crypt.viz_com import solve
@@ -73,6 +74,17 @@ class VizCom(Provider, Std):
         self.__is_debug and self.log('Files')
         self._continue = True
         ch = self.chapter
+
+        params = [
+            'device_id=3',
+            'manga_id={}'.format(self.re.search(r'/chapter/(\d+)', ch).group(1)),
+            'metadata=1',
+        ]
+        url = 'https://www.viz.com/manga/get_manga_url?' + '&'.join(params)
+        self.log(self.http_get(self.http().normalize_uri(url)))
+        __url = self.http_get(self.http().normalize_uri(url)).strip()
+        self._metadata = loads(self.http_get(__url))
+        
         params = [
             'device_id=3',
             'manga_id={}'.format(self.re.search(r'/chapter/(\d+)', ch).group(1)),
@@ -215,7 +227,7 @@ class VizCom(Provider, Std):
 
         self.after_file_save(_path, idx)
 
-        ref = solve(_path)
+        ref = solve(_path, self._metadata)
         if ref is not None:
             solved_path = _path + '-solved.jpeg'
             ref.save(solved_path)

--- a/manga_py/providers/viz_com.py
+++ b/manga_py/providers/viz_com.py
@@ -44,7 +44,19 @@ class VizCom(Provider, Std):
         return self._get_name('/chapters/([^/]+)')
 
     def get_chapters(self):
-        chapters = self._elements('a.flex[href*="/chapter/"],a.pad-r-rg.o_chapter-container[href*="/chapter/"]')
+        chapters = []
+        for chapter in self._elements('a.o_chapter-container[href*="/chapter/"]'):
+            url = chapter.get('href')
+            if url not in chapters:
+                chapters.append(url)
+        
+        # Paid chapters are dynamically loaded so we need to take a different approach.
+        re = self.re.compile(r'targetUrl:\'(.*)\',targetTitle')
+        for chapter in self._elements('a.o_chapter-container[onclick*="/chapter/"]'):
+            url = re.search(chapter.get('onclick')).group(1)
+            if url not in chapters:
+                chapters.append(url)
+
         self.__is_debug and self.log('Chapters count: %d' % len(chapters))
 
         if self.__is_debug:
@@ -53,7 +65,7 @@ class VizCom(Provider, Std):
             _path = str(page.joinpath('chapters.html'))
             self.log('Save path to %s' % _path)
             with open(_path, 'w') as w:
-                w.write('\n'.join([i.get('href') for i in chapters]))
+                w.write('\n'.join(chapters))
 
         return chapters
 

--- a/tests/matrix.py
+++ b/tests/matrix.py
@@ -203,7 +203,7 @@ class TestMatrix(unittest.TestCase):
             src_path = root_path + '/mosaic/viz/index{}.jfif'.format(i)
             ref_path = root_path + '/temp/canvas{}.png'.format(i)
             solved_path = root_path + '/mosaic/viz/canvas{}.png'.format(i)
-            ref = viz_com.solve(src_path)
+            ref = viz_com.solve(src_path, {'width': 800, 'height': 1200})
             ref.save(ref_path)
             solved = PilImage.open(solved_path)
             deviation = self._rmsdiff(solved, ref)


### PR DESCRIPTION
This merge request improves on a couple of aspects of the viz provider.

Firstly since paid chapter links are dynamically loaded into the chapters page they were not being scraped. I have adapted the scraper to extract the URLs from the `onclick` attribute as a solution to this. It also seemed that sometimes chapters were duplicated which I also fixed.

Secondly some chapters such as [1 of Naruto](https://www.viz.com/shonenjump/naruto-chapter-1/chapter/3529?action=read) were not being solved correctly since they had a height of `1195` instead of `1200` pixels. This was solved by using the height provided in the metadata JSON.

This is all in relation to #184.