### PR TITLE
enh: format `--help` prog's description and add more information.

### DIFF
--- a/manga_py/cli/args.py
+++ b/manga_py/cli/args.py
@@ -1,6 +1,9 @@
-from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter
 
 from manga_py.meta import __version__
+
+class DescriptionDefaultsHelpFormatter(ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter):
+    pass
 
 
 def _image_args(args_parser):  # pragma: no cover
@@ -83,7 +86,7 @@ def _reader_args(args_parser):  # pragma: no cover
 
 
 def get_cli_arguments() -> ArgumentParser:  # pragma: no cover
-    args_parser = ArgumentParser(add_help=False, formatter_class=ArgumentDefaultsHelpFormatter, prog="manga-py", description="%(prog)s is the universal manga downloader (for your offline reading).", epilog="So, that is how %(prog)s can be executed to download yours favourite mangas. Enjoy! 😉")
+    args_parser = ArgumentParser(add_help=False, formatter_class=DescriptionDefaultsHelpFormatter, prog="manga-py", description="%(prog)s is the universal manga downloader (for your offline reading).\n  Site: https://manga-py.com/manga-py/\n  Source-code: https://github.com/manga-py/manga-py\n  Version: " + __version__, epilog="So, that is how %(prog)s can be executed to download yours favourite mangas.\nEnjoy! 😉")
     args = args_parser.add_argument_group('General options')
 
     args.add_argument('url', metavar='URL', type=str, help='%(metavar)s, i.e. link from manga, to be downloaded.')


### PR DESCRIPTION
What
====

- Format `--help` program's description to raw way.
- Add program's information (urls, program's version) to `--help`.

Why
===

- Get a `--help` descriptions text in a Raw mode, respecting indentations.
- Add program's sites and version information.

Where
=====

On `./manga_py/cli/args.py`.

How
===

Steps to add information and formatting `--help`:

1. Create the class `DescriptionDefaultsHelpFormatter` to format two things by inheritance:
    - from RawDescriptionHelpFormatter, to print a raw-format description (identation, spaces etc).
    - from ArgumentDefaultsHelpFormatter, to print all default values on each `--help` option.
    ```python
    from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter

    from manga_py.meta import __version__

    class DescriptionDefaultsHelpFormatter(ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter):
        pass

    ```
2. Update args_parser, by
   - the ArgumentParser `formatter` parameter, using the created `DescriptionDefaultsHelpFormatter` class.
   - the ArgumentParser `description` parameter, typping new content (sites, version):
    ```python
    args_parser = ArgumentParser(add_help=False, formatter_class=DescriptionDefaultsHelpFormatter, prog="manga-py", description="%(prog)s is the universal manga downloader (for your offline reading).\n  Site: https://manga-py.com/manga-py/\n  Source-code: https://github.com/manga-py/manga-py\n  Version: " + __version__, epilog="So, that is how %(prog)s can be executed to download yours favourite mangas. Enjoy! 😉")

    ```
Results
=======

Bellow are listed a before and after states when this commit is applied:

- Before this commit:
```
(my_env) $ python3 ./manga.py --help
usage: manga-py [--version] [-n NAME] [-d PATH] [-np]
                [--not-change-files-extension] [--no-webp] [--cbz]
                [--rename-pages] [-s COUNT] [-c COUNT]
                [--user-agent USER_AGENT] [--proxy PROXY]
                [--reverse-downloading] [--rewrite-exists-archives]
                [-nm MAX_THREADS] [--zero-fill] [-N] [--min-free-space MB]
                [-h] [--print-json] [--simulate] [--show-current-chapter-info]
                [--debug] [-q]
                URL

manga-py is the universal manga downloader (for your offline reading).

General options:
  URL                   URL, i.e. link from manga, to be downloaded.
  --version             Show manga-py's version number and exit.
  -n NAME, --name NAME  Rename manga, i.e. by NAME, and its folder to where it
                        will be saved locally. (default: )
  -d PATH, --destination PATH
                        Destination folder to where the manga will be saved
                        locally, i.e. `./PATH/manga_name/`. (default: Manga)
  -np, --no-progress    Don't show progress bar. (default: False)

Image options:
  --not-change-files-extension
                        Save downloaded files to archive "as is". (default:
                        False)
  --no-webp             Convert `*.webp` images to `*.jpg` format. (default:
                        False)

Archive options:
  --cbz                 Make `*.cbz` archives (for reader). (default: False)
  --rename-pages        Normalize image filenames. E.g. from `0_page_1.jpg` to
                        `0001.jpg`. (default: False)

Downloading options:
  -s COUNT, --skip-volumes COUNT
                        Skip a total number, i.e. COUNT, of volumes. (default:
                        0)
  -c COUNT, --max-volumes COUNT
                        Download a maximum number, i.e. COUNT, of volumes.
                        E.g.: `--max-volumes 2` will download at most 2
                        volumes. If COUNT is `0` (zero) then it will download
                        all available volumes. (default: 0)
  --user-agent USER_AGENT
                        Set an user-agent. Don't work from protected sites.
                        (default: None)
  --proxy PROXY         Set a http proxy. (default: None)
  --reverse-downloading
                        Download manga volumes in a reverse order. By default,
                        the manga will be downloaded in a ascendent order
                        (i.e. volume 00, volume 01, volume 02...). If
                        `--reverse-downloading` has been actived, then the
                        manga will be downloaded in a descendent order (i.e.
                        volume 99, volume 98, volume 97...). (default: False)
  --rewrite-exists-archives
                        (Re)Download manga volume if it already exists locally
                        in the directory destination. Your manga files can be
                        overwrited, so be careful. (default: False)
  -nm MAX_THREADS, --max-threads MAX_THREADS
                        Set the maximum number of threads, i.e. MAX_THREADS,
                        to be ready to use when downloading the manga images.
                        (default: None)
  --zero-fill           Pad a `-0` (dash-and-zero) at right for all downloaded
                        manga volume filenames. E.g. from `vol_001.zip` to
                        `vol_001-0.zip`. It is useful to standardize the
                        filenames between normal manga volumes (e.g.
                        vol_006.zip) and the extra/bonuses/updated/corrected
                        manga volumes (e.g. vol_006-5.zip) released by
                        scanlators groups. (default: False)
  -N, --with-manga-name
                        Pad the manga name at left for all downloaded manga
                        volumes filenames. E.g. from `vol_001.zip` to
                        `manga_name-vol_001.zip`. (default: False)
  --min-free-space MB   Alert when the minimum free disc space, i.e. MB, is
                        reached. Insert it in order of megabytes (Mb).
                        (default: 100)

Debug / Simulation options:
  -h, --help            Show this help and exit.
  --print-json          Print information about the results in the JSON format
                        (after completion). (default: False)
  --simulate            Simulate running manga-py, where: 1) do not download
                        files and, 2) do not write anything on disk. (default:
                        False)
  --show-current-chapter-info, -cc
                        Show current processing chapter info. (default: False)
  --debug               Debug manga-py. (default: False)
  -q, --quiet           Dont show any messages. (default: False)

So, that is how manga-py can be executed to download yours favourite mangas.
Enjoy! 😉

```

- After this commit:
```
(my_env) $ python3 ./manga.py --help
usage: manga-py [--version] [-n NAME] [-d PATH] [-np]
                [--not-change-files-extension] [--no-webp] [--cbz]
                [--rename-pages] [-s COUNT] [-c COUNT]
                [--user-agent USER_AGENT] [--proxy PROXY]
                [--reverse-downloading] [--rewrite-exists-archives]
                [-nm MAX_THREADS] [--zero-fill] [-N] [--min-free-space MB]
                [-h] [--print-json] [--simulate] [--show-current-chapter-info]
                [--debug] [-q]
                URL

manga-py is the universal manga downloader (for your offline reading).
  Site: https://manga-py.com/manga-py/
  Source-code: https://github.com/manga-py/manga-py
  Version: 1.9.0

General options:
  URL                   URL, i.e. link from manga, to be downloaded.
  --version             Show manga-py's version number and exit.
  -n NAME, --name NAME  Rename manga, i.e. by NAME, and its folder to where it
                        will be saved locally. (default: )
  -d PATH, --destination PATH
                        Destination folder to where the manga will be saved
                        locally, i.e. `./PATH/manga_name/`. (default: Manga)
  -np, --no-progress    Don't show progress bar. (default: False)

Image options:
  --not-change-files-extension
                        Save downloaded files to archive "as is". (default:
                        False)
  --no-webp             Convert `*.webp` images to `*.jpg` format. (default:
                        False)

Archive options:
  --cbz                 Make `*.cbz` archives (for reader). (default: False)
  --rename-pages        Normalize image filenames. E.g. from `0_page_1.jpg` to
                        `0001.jpg`. (default: False)

Downloading options:
  -s COUNT, --skip-volumes COUNT
                        Skip a total number, i.e. COUNT, of volumes. (default:
                        0)
  -c COUNT, --max-volumes COUNT
                        Download a maximum number, i.e. COUNT, of volumes.
                        E.g.: `--max-volumes 2` will download at most 2
                        volumes. If COUNT is `0` (zero) then it will download
                        all available volumes. (default: 0)
  --user-agent USER_AGENT
                        Set an user-agent. Don't work from protected sites.
                        (default: None)
  --proxy PROXY         Set a http proxy. (default: None)
  --reverse-downloading
                        Download manga volumes in a reverse order. By default,
                        the manga will be downloaded in a ascendent order
                        (i.e. volume 00, volume 01, volume 02...). If
                        `--reverse-downloading` has been actived, then the
                        manga will be downloaded in a descendent order (i.e.
                        volume 99, volume 98, volume 97...). (default: False)
  --rewrite-exists-archives
                        (Re)Download manga volume if it already exists locally
                        in the directory destination. Your manga files can be
                        overwrited, so be careful. (default: False)
  -nm MAX_THREADS, --max-threads MAX_THREADS
                        Set the maximum number of threads, i.e. MAX_THREADS,
                        to be ready to use when downloading the manga images.
                        (default: None)
  --zero-fill           Pad a `-0` (dash-and-zero) at right for all downloaded
                        manga volume filenames. E.g. from `vol_001.zip` to
                        `vol_001-0.zip`. It is useful to standardize the
                        filenames between normal manga volumes (e.g.
                        vol_006.zip) and the extra/bonuses/updated/corrected
                        manga volumes (e.g. vol_006-5.zip) released by
                        scanlators groups. (default: False)
  -N, --with-manga-name
                        Pad the manga name at left for all downloaded manga
                        volumes filenames. E.g. from `vol_001.zip` to
                        `manga_name-vol_001.zip`. (default: False)
  --min-free-space MB   Alert when the minimum free disc space, i.e. MB, is
                        reached. Insert it in order of megabytes (Mb).
                        (default: 100)

Debug / Simulation options:
  -h, --help            Show this help and exit.
  --print-json          Print information about the results in the JSON format
                        (after completion). (default: False)
  --simulate            Simulate running manga-py, where: 1) do not download
                        files and, 2) do not write anything on disk. (default:
                        False)
  --show-current-chapter-info, -cc
                        Show current processing chapter info. (default: False)
  --debug               Debug manga-py. (default: False)
  -q, --quiet           Dont show any messages. (default: False)

So, that is how manga-py can be executed to download yours favourite mangas.
Enjoy! 😉

```

Future work
===========

- Include `--help` output onto `readme` file.
- Format (topics, identantion etc) all output from`--help` options.
- References:
    - [`ArgumentDefaultsHelpFormatter`](https://docs.python.org/3/library/argparse.html#argparse.ArgumentDefaultsHelpFormatter)
    - [`RawDescriptionHelpFormatter`](https://docs.python.org/3/library/argparse.html#argparse.RawDescriptionHelpFormatter)

---