### PR TITLE
cli: Add `--override-archive-name`

### DIFF
--- a/manga_py/cli/args.py
+++ b/manga_py/cli/args.py
@@ -71,6 +71,8 @@ def _downloading_args(args_parser):  # pragma: no cover
                       help='Pad a `-0` (dash-and-zero) at right for all downloaded manga volume filenames. E.g. from `vol_001.zip` to `vol_001-0.zip`. It is useful to standardize the filenames between normal manga volumes (e.g. vol_006.zip) and the extra/bonuses/updated/corrected manga volumes (e.g. vol_006-5.zip) released by scanlators groups.')
     args.add_argument('-N', '--with-manga-name', action='store_true',
                       help='Pad the manga name at left for all downloaded manga volumes filenames. E.g. from `vol_001.zip` to `manga_name-vol_001.zip`.')
+    args.add_argument('--override-archive-name', metavar='ARCHIVE_NAME', type=str, default='', dest='override_archive_name',
+                      help='Pad %(metavar)s at left for all downloaded manga volumes filename. E.g from `vol_001.zip` to `%(metavar)s-vol_001.zip`.')
     args.add_argument('--min-free-space', metavar='MB', type=int, default=100,
                       help='Alert when the minimum free disc space, i.e. MB, is reached. Insert it in order of megabytes (Mb).')
 

--- a/manga_py/provider.py
+++ b/manga_py/provider.py
@@ -165,8 +165,12 @@ class Provider(Base, Abstract, Static, Callbacks, ABC):
         return _path
 
     def get_archive_path(self):
-        # see Std
-        _path = remove_file_query_params(self.get_archive_name())
+        override_name = self._params.get('override_archive_name', '')
+        if override_name:
+            _path = "{}_{}".format(override_name, str(self.normal_arc_name(self.get_chapter_index().split('-'))))
+        else:
+            # see Std
+            _path = remove_file_query_params(self.get_archive_name())
         _path = self.remove_not_ascii(_path)
 
         if not _path:


### PR DESCRIPTION
This option will allow users to define the name they would like to have for the resulting archive like for example shorter names, cleaner names or simply human readable names.

I came up with this need while using my e-reader. Having my archive named vol_XXX.cbz is not userfriendly on a kobo because you do not browse your book by directory. I end up with a list of files who do not contains the manga name, if you read several manga it's hard to know which is which without opening the book. 

The second step I try is to use the option `-N` which works fine most of the time, but for manga with long name I have the name of the manga on the screen but not the chapter number. 

You might also have an issue depending on the source website the name might not be clean. For example try https://manganelo.com/manga/read_hajime_no_ippo_manga. 

```
$ docker run -v ${PWD}:/home/manga mangadl/manga-py manga-py --no-progress -N --cbz -c 1 https://manganelo.com/manga/read_hajime_no_ippo_manga
$ find Manga -type f
Manga/read_hajime_no_ippo_manga/read_hajime_no_ippo_manga-vol_001.cbz
```
You could name the manga directory with `-n` but this will not affect the archive name
```
$ docker run -v ${PWD}:/home/manga mangadl/manga-py manga-py --no-progress -N --cbz -c 1 -n hajime_no_ippo_manga https://manganelo.com/manga/read_hajime_no_ippo_manga
$ find Manga/ -type f
Manga/hajime_no_ippo_manga/read_hajime_no_ippo_manga-vol_001.cbz
```

Some time you do not end up with a human readable name due to website naming https://manganelo.com/manga/jp917635. For this one everything is correct on the webpage but the URL (where the name is extracted) does not contains the name of the manga
```
$ docker run -v ${PWD}:/home/manga mangadl/manga-py manga-py --no-progress -N --cbz -c 1 https://manganelo.com/manga/jp917635
$ find Manga -type f
Manga/jp917635/jp917635-vol_001.cbz
```

This is one of the few examples I found so far that is why I propose this patch which will solve all of those cases for any source website.

