### PR TITLE
doc: fix docker run command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ Manga-py Docker
   - Mac https://docs.docker.com/docker-for-mac/install/
   - Windows https://docs.docker.com/docker-for-windows/install/
 
-2. Install manga-py 
+2. Install manga-py
 
 .. code:: bash
     docker pull mangadl/manga-py
@@ -126,7 +126,7 @@ Manga-py Docker
 
 .. code:: bash
 
-    docker run -it -v ./:/home/manga mangadl/manga-py
+    docker run -it -v ${PWD}:/home/manga mangadl/manga-py
 
 
 Or docker-compose:
@@ -177,4 +177,4 @@ Or docker-compose:
    :alt: PyPI - Downloads
 .. |PyPI - size| image:: https://img.shields.io/badge/dynamic/json?color=success&label=PyPI+size&query=%24.size&url=https://sttv.me/manga-py.json&?cacheSeconds=3600&suffix=+Kb
    :alt: PyPI - size
-   
+


### PR DESCRIPTION
fix usage of docker run `-v` command

```
$ docker run -it -v ./:/home/manga mangadl/manga-py manga-py --version
docker: Error response from daemon: create ./: "./" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
$ docker run -v ${PWD}:/home/manga mangadl/manga-py manga-py --version
1.8.5
```