### PR TITLE
fix type check

### DIFF
--- a/manga_py/info.py
+++ b/manga_py/info.py
@@ -61,7 +61,7 @@ class Info:
         return dt.strftime(fmt)
 
     def __init__(self, args: Union[Namespace, dict]):  # see manga_py.cli arguments
-        _args = args.__dict__ if args is not dict else args
+        _args = args.__dict__ if not isinstance(args, dict) else args
         _args['_raw_params'] = ' '.join(argv)
         self._data = {
             'site': args.url,


### PR DESCRIPTION
I wanted to play with the embedded (awesome) `manga-py` but got an issue with type check in `Info` class at https://github.com/manga-py/manga-py/blob/3eebce7ed77aac8202b0a7daf040a64acfe1ec6e/manga_py/info.py#L64

```text
Traceback (most recent call last):
  File "/Users/frederic/devops/github/manga-pie/main.py", line 143, in <module>
    try_mangapy()
  File "/Users/frederic/devops/github/manga-pie/main.py", line 35, in try_mangapy
    print(Info(mpy_args))
  File "/Users/frederic/Library/Python/3.9/lib/python/site-packages/manga_py/info.py", line 65, in __init__
    _args = args.__dict__ if args is not dict else args
AttributeError: 'dict' object has no attribute '__dict__'
```

Shouldn't type check be using [`isintance`](https://docs.python.org/3/library/functions.html#isinstance) ?

```python
thedict = dict()
print("iamnotadict") if thedict is not dict else print("iamadict")
iamnotadict
print("iamnotadict") if not isinstance(thedict, dict) else print("iamadict")
iamadict
```