### PR TITLE
add --flare-solver-url arg type

### DIFF
--- a/manga_py/cli/_args_downloading.py
+++ b/manga_py/cli/_args_downloading.py
@@ -204,6 +204,7 @@ def _args_downloading(args_parser):  # pragma: no cover
     args.add_argument(
         '--flare-solver-url',
         metavar='URL',
+        type=str,
         help=(
             'Flare solver url (see https://github.com/manga-py/manga-py/issues/413'
         )


### PR DESCRIPTION
When executing `python manga.py` version 1.33.0, I am getting an error `'NoneType' object has no attribute '__name__'` [here](https://github.com/manga-py/manga-py/blob/2baaff7a8b99af7ee51801f0af512511b21f89da/manga_py/util.py#L106).

This commit seems to fix it.

