### PR TITLE
version 3.11 doesn't work with PIL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,8 @@ How to use
 Installation
 ~~~~~~~~~~~~
 
-1) Download python 3.6+ https://docs.conda.io/en/latest/miniconda.html
+1) Download python 3.6 to 3.9
+   https://docs.conda.io/en/latest/miniconda.html 
 2) Install pip package:
 
 .. code:: bash


### PR DESCRIPTION
Error with PIL:
Pillow 8.4.0 does not support Python 3.11 and does not provide prebuilt Windows binaries
